### PR TITLE
Added Stars component

### DIFF
--- a/src/components/Stars.jsx
+++ b/src/components/Stars.jsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import styles from "./stars.module.css";
+
+const Stars = ({rating}) => {
+  const [rounded, setRating] = useState((Math.round(rating * 4) / 4));
+  
+  return (
+    <div className={styles.Stars} style={{'--rating': rounded}} aria-label={"Rating of this product is " + rounded + " out of 5."}></div>
+  )
+}
+
+export default Stars;

--- a/src/components/stars.module.css
+++ b/src/components/stars.module.css
@@ -1,0 +1,19 @@
+:root {
+  --star-size: 25px;
+  --star-color: #fff;
+  --star-background: #fc0;
+}
+.Stars {
+  --percent: calc(var(--rating) / 5 * 100%);
+  /* display: inline-block; */
+  font-size: var(--star-size);
+  font-family: Times;
+  line-height: 1;
+}
+.Stars::before {
+  content: '★★★★★';
+  letter-spacing: 3px;
+  background: linear-gradient(90deg, var(--star-background) var(--percent), var(--star-color) var(--percent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}


### PR DESCRIPTION
Added a star component that takes in a `rating` prop and then rounds it to the nearest quarter before rendering it as graph of 5 stars filled according to the passed in rounded rating.

[Trello Ticket](https://trello.com/c/SFi4Aeyf)

Zero Stars
![image](https://user-images.githubusercontent.com/54276174/139908219-52be3ba0-34d4-457c-92d1-d7b84961110d.png)

Five Stars
![image](https://user-images.githubusercontent.com/54276174/139908290-7be3fa96-4588-4f57-a2d8-3b8b85113a12.png)

One and a Quarter Stars
![image](https://user-images.githubusercontent.com/54276174/139908327-2a30c2ea-8261-4f3e-a089-0cdf9605c528.png)
