### PR TITLE
Product breakdown now using dynamic data

### DIFF
--- a/src/components/reviews/ProductBreakdown.jsx
+++ b/src/components/reviews/ProductBreakdown.jsx
@@ -1,20 +1,24 @@
 import React from 'react'
 import styles from "./reviews.module.css";
+import { useProductContext } from '../../context/ProductContext.jsx'
 
 const ProductBreakdown = () => {
+  const {meta} = useProductContext();
+  const characteristics = meta.characteristics;
+
   return (
     <div className={styles.productBreakdown}>
-      {scores.map((score, index) => {
+      {Object.keys(characteristics).map((key, index) => {
         return (
-          <div key={index} className={styles.characteristic}>
-            <p>{score.label}</p>
+          <div key={characteristics[key]} className={styles.characteristic}>
+            <p>{key}</p>
             <div className={styles.scoreBar}>
-              <div className={styles.arrowDown} style={{'--score': score.score}}></div>
+              <div className={styles.arrowDown} style={{'--score': characteristics[key].value}}></div>
             </div>
             <div className={styles.subLabels}>
-              <div>{subLabel[score.label][0]}</div>
-              <div>{subLabel[score.label][1]}</div>
-              <div>{subLabel[score.label][2]}</div>
+              <div>{subLabel[key][0]}</div>
+              <div>{subLabel[key][1]}</div>
+              <div>{subLabel[key][2]}</div>
             </div>
           </div>
         )
@@ -23,20 +27,6 @@ const ProductBreakdown = () => {
   );
 }
 
-var scores = [
-  {
-    label: 'Size',
-    score: 3.4,
-  },
-  {
-    label: 'Width',
-    score: 1,
-  },
-  {
-    label: 'Quality',
-    score: 4,
-  }
-]
 
 var subLabel = {
   Size: ['Too small', 'Perfect', 'Too large'],


### PR DESCRIPTION
This is a small change. I imported the useProductContext, used it to get the meta data and then updated my return value to use the meta data instead of the test data I was using. I also removed the test data from the bottom.

(Trello Ticket)[https://trello.com/c/qwcKJqNP]

Before
![image](https://user-images.githubusercontent.com/54276174/140447129-6ace5380-e13f-4197-9bd1-d198b56c0270.png)

After
![image](https://user-images.githubusercontent.com/54276174/140447148-391dfcc0-9529-4b40-a8ca-d62fd8e02a13.png)
