### PR TITLE
Cleaned up css for modal and added scrolling functionality

### DIFF
--- a/src/components/questions/questions.module.css
+++ b/src/components/questions/questions.module.css
@@ -111,9 +111,9 @@ input[name=question] {
 .modal {
   width: 80%;
   background: white;
-  border: 1px solid gray;
   z-index: 1;
   position: absolute;
+  top: 10%;
 }
 
 .modal .content {
@@ -121,13 +121,13 @@ input[name=question] {
   z-index: 10;
   margin: auto;
   position: fixed;
-  top: 100px;
   left: 25%;
+  max-height: 80vh;
   border: 1px solid gray;
   width: 40%;
   min-width: 400px;
   background-color: white;
-
+  overflow: scroll;
 }
 
 .modal .actions {


### PR DESCRIPTION
@ygroener Yosef, could you take a look at this and let me know what you think? The main thing I needed to change on the modal was to make it so that it has scroll functionality and I figured since I was there I would refactor some other parts.

The main changes I made:
- In .modal 
  - Got rid of the border in the .modal class (this was what was giving it the weird line)
  - Add a 80vh max height so that at most the modal takes up 80% of the height
  - Made it's top 10% so that when it is at max height it is centered vertically in the screen (We can discuss further how to get it centered all the time)
- in .modal .content
  - Removed top so that the content just lines up with the .modal (which is 10% top)
  - Removed some other styles that didn't seem to be making a difference (Please let me know if I'm mistaken and there was a reason for them)
  - Added overflow:scroll so longer content in modals will be scrollable