### PR TITLE
Fixed bug to add dynamic clicking functionality to related products!

### DIFF
--- a/src/components/questions/QuestionList.jsx
+++ b/src/components/questions/QuestionList.jsx
@@ -26,10 +26,11 @@ const QuestionList = (props) => {
   // This code sets the length of the displayed questions (default is 2)
   const [displayedQuestions, setDisplayed] = useState(jsxQuestions.slice(0, 2));
 
-  console.log('jsx questions:', jsxQuestions)
-  useEffect(() => {
-    setDisplayed(jsxQuestions.slice(0, 2));
-  }, [jsxQuestions])
+  // This should update the Q&A component so it defaults to show 2 questions, however right now including this useEffect breaks the related product click functionality so I am not including it
+
+  // useEffect(() => {
+  //   setDisplayed(jsxQuestions.slice(0, 2));
+  // }, [jsxQuestions])
 
   // Each click extends list of questions by up to 2
   let moreQuestionsClick = () => {

--- a/src/components/questions/QuestionList.jsx
+++ b/src/components/questions/QuestionList.jsx
@@ -26,6 +26,11 @@ const QuestionList = (props) => {
   // This code sets the length of the displayed questions (default is 2)
   const [displayedQuestions, setDisplayed] = useState(jsxQuestions.slice(0, 2));
 
+  console.log('jsx questions:', jsxQuestions)
+  useEffect(() => {
+    setDisplayed(jsxQuestions.slice(0, 2));
+  }, [jsxQuestions])
+
   // Each click extends list of questions by up to 2
   let moreQuestionsClick = () => {
     if (jsxQuestions.length > displayedQuestions.length) {

--- a/src/components/questions/QuestionList.jsx
+++ b/src/components/questions/QuestionList.jsx
@@ -9,23 +9,28 @@ const QuestionList = (props) => {
 
   // Added actual questions using context
   const {questions} = useProductContext();
-  let allQuestions = questions.results;
 
+  // This creates a jsxQuestions state variables to track the questions and store them as jsx question elements
 
+  const [jsxQuestions, updateJSX] = useState([]);
 
-  let items = allQuestions.map((question, i) => {
-    return (
-      <Question question={question} key={i} questionid={question.question_id}/>
-    )
-  })
+  // This updates the jxs question elements when new data comes in from context
+  useEffect(() => {
+    updateJSX(questions.results.map((question, i) => {
+      return (
+        <Question question={question} key={i} questionid={question.question_id}/>
+      )
+    }))
+  }, [questions])
+
   // This code sets the length of the displayed questions (default is 2)
-  const [displayedQuestions, setDisplayed] = useState(items.slice(0, 2));
+  const [displayedQuestions, setDisplayed] = useState(jsxQuestions.slice(0, 2));
 
   // Each click extends list of questions by up to 2
   let moreQuestionsClick = () => {
-    if (items.length > displayedQuestions.length) {
+    if (jsxQuestions.length > displayedQuestions.length) {
       let length = displayedQuestions.length;
-      setDisplayed(items.slice(0, length + 2));
+      setDisplayed(jsxQuestions.slice(0, length + 2));
     }
   }
 
@@ -35,10 +40,10 @@ const QuestionList = (props) => {
         {displayedQuestions}
       </ul>
       <div className={styles.questionListButtons}>
-        {(displayedQuestions.length < items.length) &&
+        {(displayedQuestions.length < jsxQuestions.length) &&
         <button className='button' onClick={moreQuestionsClick}>More Answered Questions</button>
       }
-      {(displayedQuestions.length === items.length && items.length > 2) && <button className='button' onClick={ () => setDisplayed(items.slice(0, 2))}>Collapse Questions</button> }
+      {(displayedQuestions.length === jsxQuestions.length && jsxQuestions.length > 2) && <button className='button' onClick={ () => setDisplayed(jsxQuestions.slice(0, 2))}>Collapse Questions</button> }
       <AddQuestion/>
       </div>
     </div>

--- a/src/components/related/ProductCard.jsx
+++ b/src/components/related/ProductCard.jsx
@@ -19,7 +19,7 @@ const ProductCard = ({relatedProduct, update}) =>{
   };
 
   const changeCurrentProduct = () =>{
-    // update(relatedProduct.info.id)
+    update(relatedProduct.info.id)
     setTimeout(() =>  window.scrollTo({
         top: 0,
         left: 0,


### PR DESCRIPTION
I did this by changing the way my questions list component mapped out individual question components.
I made it so that this was done strictly using state, without any intermediate variables involved, and then added a useEffect so that the question elements update whenever the data coming in from context changes.

This gave a minor bug so that my question list now defaults to being completely minimized rather than showing 2 questions, but for the demo I will just have the question list expanded already to show.

-My computer is lagging but there may be an issue where it only lets you dynamically render the page for a new product once.

Thank you for reviewing!!
